### PR TITLE
Follow Swift5.1 syntax

### DIFF
--- a/Example/SampleViewModel.swift
+++ b/Example/SampleViewModel.swift
@@ -28,6 +28,14 @@ enum Test {
     case hellow
 }
 
+enum TestEnumSyntaxWithDefaultValue {
+    case success1(String = "test")
+    case success2(Int? = nil)
+    case success3(label: String = "")
+    case warning1(lebel: Bool = false)
+    case warnining2(label: Bool = true)
+}
+
 // test text sampl
 // misspell
 final class SampleViewModel: SampleViewModelInputs, SampleViewModelOutputs, SampleViewModelCoordinatorOutputs, SampleViewModeling {

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,18 +5,18 @@
         "package": "llbuild",
         "repositoryURL": "https://github.com/apple/swift-llbuild.git",
         "state": {
-          "branch": "master",
-          "revision": "d603a1641614065415d92af008fc60c1f1ea07ed",
-          "version": null
+          "branch": null,
+          "revision": "f73b84bc1525998e5e267f9d830c1411487ac65e",
+          "version": "0.2.0"
         }
       },
       {
         "package": "SwiftPM",
         "repositoryURL": "https://github.com/apple/swift-package-manager.git",
         "state": {
-          "branch": "swift-5.1-DEVELOPMENT-SNAPSHOT-2019-04-25-a",
-          "revision": "a1c685bec46b2e7fbb6eba9c43a3be7954257f74",
-          "version": null
+          "branch": null,
+          "revision": "9abcc2260438177cecd7cf5185b144d13e74122b",
+          "version": "0.5.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-syntax.git",
         "state": {
           "branch": null,
-          "revision": "43aa4a19b8105a803d8149ad2a86aa53a77efef3",
-          "version": "0.50000.0"
+          "revision": "3e3eb191fcdbecc6031522660c4ed6ce25282c25",
+          "version": "0.50100.0"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/ezura/SwiftSyntaxExtensions.git",
         "state": {
           "branch": null,
-          "revision": "a353d82e20d902d9b7592beeb7da085cf7dd3232",
-          "version": "0.50000.0"
+          "revision": "7c49cae91939feb503e560e0df12668b19a11e4d",
+          "version": "0.50100.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -9,8 +9,8 @@ let package = Package(
         .executable(name: "typokana", targets: ["typokana"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-syntax.git", .exact("0.50000.0")),
-        .package(url: "https://github.com/ezura/SwiftSyntaxExtensions.git", .exact("0.50000.0")),
+        .package(url: "https://github.com/apple/swift-syntax.git", .exact("0.50100.0")),
+        .package(url: "https://github.com/ezura/SwiftSyntaxExtensions.git", .exact("0.50100.0")),
         .package(url: "https://github.com/apple/swift-package-manager.git", .exact("0.5.0")),
     ],
     targets: [

--- a/Sources/typokana/main.swift
+++ b/Sources/typokana/main.swift
@@ -63,8 +63,10 @@ do {
     }
 
     try targetFiles.forEach { 
-        let syntaxTree = try SyntaxTreeParser.parse($0.asURL)
-        syntaxTree.walk(SpellVisitor(filePath: $0.pathString, spellChecker: spellChecker))
+        let syntaxTree = try SyntaxParser.parse($0.asURL)
+        let sourceLocationConverter = SourceLocationConverter(file: $0.pathString, tree: syntaxTree)
+        var spellVisitor = SpellVisitor(filePath: $0.pathString, spellChecker: spellChecker, sourceLocationConverter: sourceLocationConverter)
+        syntaxTree.walk(&spellVisitor)
     }
 } catch {
     print(error.localizedDescription)


### PR DESCRIPTION
# What
Resolve issue https://github.com/ezura/spell-checker-for-swift/issues/10

# Why
When `typokana` reads new syntax of Swift5.1, a decode error occurs.
```swift
enum Sample {
    case e(Int = 1)
}
```
```
The operation couldn’t be completed. (SwiftSyntax.TokenKind.DecodeError error 0.)
```

# How
* Update versions of used SwiftSyntax and relative module
* Follow changes of SwiftSyntax