### PR TITLE
Improved --diff-only

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,17 +24,17 @@
         "repositoryURL": "https://github.com/apple/swift-syntax.git",
         "state": {
           "branch": null,
-          "revision": "3e3eb191fcdbecc6031522660c4ed6ce25282c25",
-          "version": "0.50100.0"
+          "revision": "0688b9cfc4c3dd234e4f55f1f056b2affc849873",
+          "version": "0.50200.0"
         }
       },
       {
         "package": "SwiftSyntaxExtensions",
-        "repositoryURL": "https://github.com/ezura/SwiftSyntaxExtensions.git",
+        "repositoryURL": "https://github.com/youfoodz/SwiftSyntaxExtensions.git",
         "state": {
-          "branch": null,
-          "revision": "7c49cae91939feb503e560e0df12668b19a11e4d",
-          "version": "0.50100.0"
+          "branch": "master",
+          "revision": "cfb57b04a9759b015e73b803be1b49c0db05f42c",
+          "version": null
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -9,8 +9,8 @@ let package = Package(
         .executable(name: "typokana", targets: ["typokana"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-syntax.git", .exact("0.50100.0")),
-        .package(url: "https://github.com/ezura/SwiftSyntaxExtensions.git", .exact("0.50100.0")),
+        .package(url: "https://github.com/apple/swift-syntax.git", .exact("0.50200.0")),
+        .package(url: "https://github.com/youfoodz/SwiftSyntaxExtensions.git", .branch("master")),
         .package(url: "https://github.com/apple/swift-package-manager.git", .exact("0.5.0")),
     ],
     targets: [

--- a/Sources/typokana/FileUtil.swift
+++ b/Sources/typokana/FileUtil.swift
@@ -20,7 +20,7 @@ func visitFiles(in root: AbsolutePath, onFind: (AbsolutePath) throws -> Void) re
 }
 
 func extractModifiedFiles() throws -> [String] {
-    let processOfGitDiff = Process(args: "git", "diff", "--name-only")
+    let processOfGitDiff = Process(args: "git", "diff", "--diff-filter=d", "--name-only", "HEAD")
     try processOfGitDiff.launch()
     let result = try processOfGitDiff.waitUntilExit()
     return try result.utf8Output().split(separator: "\n").map { String($0) }

--- a/Sources/typokana/SpellVisitor.swift
+++ b/Sources/typokana/SpellVisitor.swift
@@ -21,7 +21,7 @@ class SpellVisitor: SyntaxVisitor {
         self.sourceLocationConverter = sourceLocationConverter
     }
     
-    func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind {
+    override func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind {
         for comment in token.leadingTrivia.compactMap({ $0.comment }) {
             let misspellRange = spellChecker.checkSpelling(of: comment, startingAt: 0)
             if misspellRange.location < comment.count {

--- a/Sources/typokana/main.swift
+++ b/Sources/typokana/main.swift
@@ -65,8 +65,8 @@ do {
     try targetFiles.forEach { 
         let syntaxTree = try SyntaxParser.parse($0.asURL)
         let sourceLocationConverter = SourceLocationConverter(file: $0.pathString, tree: syntaxTree)
-        var spellVisitor = SpellVisitor(filePath: $0.pathString, spellChecker: spellChecker, sourceLocationConverter: sourceLocationConverter)
-        syntaxTree.walk(&spellVisitor)
+        let spellVisitor = SpellVisitor(filePath: $0.pathString, spellChecker: spellChecker, sourceLocationConverter: sourceLocationConverter)
+        spellVisitor.walk(syntaxTree)
     }
 } catch {
     print(error.localizedDescription)


### PR DESCRIPTION
* Added flag to ignore deleted files. Prevents 'The file "$filename" couldn't be opened because there is no such file' error from being printed.
* Diff is done from HEAD so that both staged and unstaged files are checked. This makes it easier to use in a pre-commit hook where the files you would want to be checked would already be staged.