### PR TITLE
Updated for Swift 5.2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -30,11 +30,11 @@
       },
       {
         "package": "SwiftSyntaxExtensions",
-        "repositoryURL": "https://github.com/youfoodz/SwiftSyntaxExtensions.git",
+        "repositoryURL": "https://github.com/ezura/SwiftSyntaxExtensions.git",
         "state": {
-          "branch": "master",
-          "revision": "cfb57b04a9759b015e73b803be1b49c0db05f42c",
-          "version": null
+          "branch": null,
+          "revision": "1187a8779d5de054a41c1a8f556658aaef4c79c5",
+          "version": "0.50200.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-syntax.git", .exact("0.50200.0")),
-        .package(url: "https://github.com/youfoodz/SwiftSyntaxExtensions.git", .branch("master")),
+        .package(url: "https://github.com/ezura/SwiftSyntaxExtensions.git", .exact("0.50200.0")),
         .package(url: "https://github.com/apple/swift-package-manager.git", .exact("0.5.0")),
     ],
     targets: [


### PR DESCRIPTION
A draft PR with the required changes needed to support Swift 5.2.
Needs https://github.com/ezura/SwiftSyntaxExtensions/pull/2 to be approved and a new release tagged and `Package.resolved` updated before it can be merged in.