### PR TITLE
Bump versions

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,21 +2,57 @@
   "object": {
     "pins": [
       {
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
+        "state": {
+          "branch": null,
+          "revision": "e394bf350e38cb100b6bc4172834770ede1b7232",
+          "version": "1.0.3"
+        }
+      },
+      {
+        "package": "swift-collections",
+        "repositoryURL": "https://github.com/apple/swift-collections.git",
+        "state": {
+          "branch": null,
+          "revision": "937e904258d22af6e447a0b72c0bc67583ef64a2",
+          "version": "1.0.4"
+        }
+      },
+      {
+        "package": "swift-crypto",
+        "repositoryURL": "https://github.com/SDGGiesbrecht/swift-crypto",
+        "state": {
+          "branch": null,
+          "revision": "477051bcb0f29f01b7f22ef3dab5ebbe6962246d",
+          "version": "0.10107.0"
+        }
+      },
+      {
+        "package": "swift-driver",
+        "repositoryURL": "https://github.com/SDGGiesbrecht/swift-driver",
+        "state": {
+          "branch": null,
+          "revision": "cf45d612ff5de77db97308a5da3f0114a95486e1",
+          "version": "0.50700.1"
+        }
+      },
+      {
         "package": "llbuild",
         "repositoryURL": "https://github.com/apple/swift-llbuild.git",
         "state": {
           "branch": null,
-          "revision": "f73b84bc1525998e5e267f9d830c1411487ac65e",
-          "version": "0.2.0"
+          "revision": "5cd4df550b31301508a77064e3dfaa5c5628780e",
+          "version": "0.5.0"
         }
       },
       {
         "package": "SwiftPM",
-        "repositoryURL": "https://github.com/apple/swift-package-manager.git",
+        "repositoryURL": "https://github.com/SDGGiesbrecht/swift-package-manager.git",
         "state": {
           "branch": null,
-          "revision": "9abcc2260438177cecd7cf5185b144d13e74122b",
-          "version": "0.5.0"
+          "revision": "cdaee539e1f417367f7b88b6bb263a81349f282c",
+          "version": "0.50700.1"
         }
       },
       {
@@ -24,17 +60,44 @@
         "repositoryURL": "https://github.com/apple/swift-syntax.git",
         "state": {
           "branch": null,
-          "revision": "844574d683f53d0737a9c6d706c3ef31ed2955eb",
-          "version": "0.50300.0"
+          "revision": "cd793adf5680e138bf2bcbaacc292490175d0dcd",
+          "version": "508.0.0"
+        }
+      },
+      {
+        "package": "swift-system",
+        "repositoryURL": "https://github.com/apple/swift-system.git",
+        "state": {
+          "branch": null,
+          "revision": "836bc4557b74fe6d2660218d56e3ce96aff76574",
+          "version": "1.1.1"
+        }
+      },
+      {
+        "package": "swift-tools-support-core",
+        "repositoryURL": "https://github.com/apple/swift-tools-support-core",
+        "state": {
+          "branch": null,
+          "revision": "4f07be3dc201f6e2ee85b6942d0c220a16926811",
+          "version": "0.2.7"
         }
       },
       {
         "package": "SwiftSyntaxExtensions",
-        "repositoryURL": "https://github.com/ezura/SwiftSyntaxExtensions.git",
+        "repositoryURL": "https://github.com/rokasambrazevicius2/SwiftSyntaxExtensions.git",
+        "state": {
+          "branch": "updateVersion",
+          "revision": "476db726619a1a9f81f1fff165ad06bffbae87cc",
+          "version": null
+        }
+      },
+      {
+        "package": "Yams",
+        "repositoryURL": "https://github.com/jpsim/Yams.git",
         "state": {
           "branch": null,
-          "revision": "504d566c52b78155592ef4ba48234e3d240bddbc",
-          "version": "0.50300.0"
+          "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
+          "version": "4.0.6"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,17 +1,23 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "typokana",
+    platforms: [
+        .macOS(.v10_15)
+    ],
     products: [
         .executable(name: "typokana", targets: ["typokana"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-syntax.git", .exact("0.50300.0")),
-        .package(url: "https://github.com/ezura/SwiftSyntaxExtensions.git", .exact("0.50300.0")),
-        .package(url: "https://github.com/apple/swift-package-manager.git", .exact("0.5.0")),
+        .package(url: "https://github.com/apple/swift-syntax.git", .exact("508.0.0")),
+        .package(
+            url:"https://github.com/rokasambrazevicius2/SwiftSyntaxExtensions.git",
+            .branchItem("updateVersion")
+        ),
+        .package(url: "https://github.com/SDGGiesbrecht/swift-package-manager.git", .exact("0.50700.1"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -20,8 +26,9 @@ let package = Package(
             name: "typokana",
             dependencies: [
                 "SwiftSyntax",
+                "SwiftSyntaxParser",
                 "SwiftSyntaxExtensions",
-                "SPMUtility",
+                "SwiftPM"
             ]),
         .testTarget(
             name: "typokanaTests",

--- a/Sources/typokana/FileUtil.swift
+++ b/Sources/typokana/FileUtil.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import Basic
+import TSCBasic
 
 func visitFiles(in root: AbsolutePath, onFind: (AbsolutePath) throws -> Void) rethrows {
     if root.extension == "swift" {

--- a/Sources/typokana/IgnoredWordList.swift
+++ b/Sources/typokana/IgnoredWordList.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import Basic
+import TSCBasic
 
 enum IgnoredWordList {
     

--- a/Sources/typokana/SpellVisitor.swift
+++ b/Sources/typokana/SpellVisitor.swift
@@ -19,6 +19,8 @@ class SpellVisitor: SyntaxVisitor {
         self.filePath = filePath
         self.spellChecker = spellChecker
         self.sourceLocationConverter = sourceLocationConverter
+
+        super.init(viewMode: .all)
     }
     
     override func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind {

--- a/Sources/typokana/main.swift
+++ b/Sources/typokana/main.swift
@@ -7,9 +7,10 @@
 
 import Foundation
 import Cocoa
-import SPMUtility
-import Basic
+import TSCUtility
+import TSCBasic
 import SwiftSyntax
+import SwiftSyntaxParser
 
 let parser = ArgumentParser(usage: "[options] argument", overview: "Spell check")
 let arg = parser.add(positional: "path | init",


### PR DESCRIPTION
Update package versions.
Rename `Basic` -> `TSCBasic `.
Rename `SPMUtility` -> `TSCUtility `.

Haven't used the library before, not sure about `super.init(viewMode: .all)` in `SpellVisitor.swift`.

